### PR TITLE
Once of the bugs which prevented signalR transport negotiation due to II...

### DIFF
--- a/src/BugTracker/Views/Home/Index.cshtml
+++ b/src/BugTracker/Views/Home/Index.cshtml
@@ -17,9 +17,7 @@
                 viewModel.moveBug(item);
             };
 
-            //Bug: On Helios allowing client to negotiate transport creates some issues : https://github.com/aspnet/Helios/issues/14
-            //On selfhost it works fine. We will remove the hardcoded transport once we have the Helios bug fixed. 
-            $.connection.hub.start({ transport: 'longPolling' }).done(function () {
+            $.connection.hub.start().done(function () {
                 console.log('hub connection open');
             });
 


### PR DESCRIPTION
...S express compression is fixed. Uncommenting the code to enable this.
