### PR TITLE
appSetting "K" to specify the CLR to be loaded not anymore honored

### DIFF
--- a/src/BugTracker/Web.config
+++ b/src/BugTracker/Web.config
@@ -7,9 +7,6 @@
   </system.web>
 
   <appSettings>
-    <!-- Change below value to 'false' to run on full desktop -->
-    <add key="K" value="true" />
-
     <!-- This will turn on detailed errors when deployed to remote servers -->
     <!-- This setting is not recommended for production -->
     <add key="K_DETAILED_ERRORS" value="true" />


### PR DESCRIPTION
Removing the setting from web.config
