### PR TITLE
Removing ~ from the api/bugs REST url

### DIFF
--- a/src/BugTracker/Views/Home/Index.cshtml
+++ b/src/BugTracker/Views/Home/Index.cshtml
@@ -21,7 +21,7 @@
                 console.log('hub connection open');
             });
 
-            var bugsBaseAddress = encodeURIComponent('@Url.Content("~/api/bugs/")');
+            var bugsBaseAddress = encodeURIComponent('/api/bugs/');
             $.getJSON(bugsBaseAddress, function (data) {
                 var model = data;
 


### PR DESCRIPTION
encodeURIComponent seems to add the app vDir name again. So removing ~ as it leads to non-existent resource location.
