### PR TITLE
Adding Kestrel package to BugTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,22 @@
-## BugTracker application
+# BugTracker application
 
-###Getting Started
+This project is part of ASP.NET vNext. You can find samples, documentation and getting started instructions for ASP.NET vNext at the [Home](https://github.com/aspnet/home) repo.
 
-The first thing we need to do is setup the tools required to build and run an application.
+### Run the application on Helios:
+* Execute ```build.cmd``` to restore all the necessary packages, and run tests.
+**NOTE: Tests require Visual Studio 2014 LocalDB on the machine to run. 
+* Open MusicStore.sln in Visual Studio 2014 and run the individual applications on ```Helios```.
 
-* If you already have ```kvm``` installed on the machine ignore the steps below.
-* Clone [Home] (https://github.com/aspnet/Home) repository
-* On the command line, cd to Home repository and execute ```kvm setup``` 
-* This command will download the latest version of the SDK and put it on your path so that you can run the rest of the commands in the readme. If you want to know more about what this is doing then you can read the [KVM page](https://github.com/aspnet/Home/wiki/version-manager) of the wiki.
-* On the command line execute ```kvm install 0.1-alpha-build-0421```
-* This command will install Desktop flavor(x86) of KRE build 0421 in your user profile
-* Clone BugTracker repository, if you have not already
-
-### Run the application:
-1. Open a command prompt and cd ```\src\<AppFolder>\```
-2. Run ```kpm restore``` to restore all the necessary packages and generate project files
-   Note: ```kpm restore``` currently works only on Desktop flavor. If you intend to use Core CLR, you should get Desktop flavor, execute ```kpm restore``` and then switch to Core CLR
-3. **[Helios]:**
-	4. ```Helios.cmd``` to launch the app on IISExpress (Application started at URL **http://localhost:5001/**).
-4. **[SelfHost]:**
-	5. Run ```k web``` (Application started at URL **http://localhost:5002/**)
-5. **[CustomHost]:**
+### Run on WebListener/Kestrel:
+* Open a command prompt and cd ```\src\BugTracker\```
+* **[Helios]:**
+	4. ```Helios.cmd``` to launch the app on IISExpress from command line (Application started at URL **http://localhost:5001/**).
+* **[WebListener]:**
+	5. Run ```k WebListener``` (Application started at URL **http://localhost:5002/**)
+* **[Kestrel]:**
+	5. Run ```k Kestrel``` (Application started at URL **http://localhost:5004/**)
+* **[CustomHost]:**
 	6. Run ```k run``` (This hosts the app in a console application - Application started at URL **http://localhost:5003/**)
 
-### Switching between Desktop CLR and CoreCLR:
-By default the app runs on desktop CLR. To switch to run the app on CoreCLR follow the steps below
-* On the command line, execute ```kvm install 0.1-alpha-build-0421 -svrc50```
-* This command will install core clr flavor of KRE build 0421 and set runtime to core clr 0421 build.
-* If you want to run on IIS/IISExpress against core clr, open k.ini and update KRE_FLAVOR to CORECLR and follow steps for running the application from 'Run the application' section
-* If you want to run on SelfHost against core clr, follow steps for running the application from 'Run the application' section
-
-### Adding a new package:
-1. Edit the project.json to include the package you want to install.
-2. Do a ```kpm restore``` - This will restore the package in the project.
-
-### Work against the latest build:
-1. Run ```Clean.cmd``` - This will clear all the packages and any temporary files generated
-2. Continue the topic "Run the application"
-
 ### Note:
-1. Application is started on different ports on different hosts. To change the port or URL modify ```Helios.cmd``` or project.json commands section in case of self-host and customhost. 
+1. Application is started on different ports on different hosts. To change the port or URL modify ```Helios.cmd``` or project.json commands section in case of self-host and customhost.

--- a/src/BugTracker/Startup.cs
+++ b/src/BugTracker/Startup.cs
@@ -1,53 +1,49 @@
-using Microsoft.AspNet;
 using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.AspNet.Diagnostics;
-using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Routing;
-using Microsoft.AspNet.SignalR;
 
-    public class Startup
+public class Startup
+{
+    public void Configure(IBuilder app)
     {
-        public void Configure(IBuilder app)
+        /* Error page middleware displays a nice formatted HTML page for any unhandled exceptions in the request pipeline.
+        * Note: ErrorPageOptions.ShowAll to be used only at development time. Not recommended for production.
+        */
+        app.UseErrorPage(ErrorPageOptions.ShowAll);
+
+        app.UseServices(services =>
         {
-            /* Error page middleware displays a nice formatted HTML page for any unhandled exceptions in the request pipeline.
-            * Note: ErrorPageOptions.ShowAll to be used only at development time. Not recommended for production.
-            */
-            app.UseErrorPage(ErrorPageOptions.ShowAll);
+            //Add all MVC related services to IoC.
+            services.AddMvc();
 
-            app.UseServices(services =>
-            {
-                //Add all MVC related services to IoC.
-                services.AddMvc();
+            //Add all SignalR related services to IoC.
+            services.AddSignalR();
+        });
 
-                //Add all SignalR related services to IoC.
-                services.AddSignalR();
-            });
+        //Configure SignalR
+        app.UseSignalR();
 
-            //Configure SignalR
-            app.UseSignalR();
+        //Serves static files in the application.
+        app.UseFileServer();
 
-            //Serves static files in the application.
-            app.UseFileServer();
+        //Configure WebFx
+        app.UseMvc(routes =>
+        {
+            routes.MapRoute(
+                null,
+                "{controller}/{action}",
+                new { controller = "Home", action = "Index" });
 
-            //Configure WebFx
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    null,
-                    "{controller}/{action}",
-                    new { controller = "Home", action = "Index" });
+            routes.MapRoute(
+                null,
+                "api/{controller}/{action}",
+                new { controller = "Home", action = "Index" });
 
-                routes.MapRoute(
-                    null,
-                    "api/{controller}/{action}",
-                    new { controller = "Home", action = "Index" });
-
-                routes.MapRoute(
-                    null,
-                    "api/{controller}",
-                    new { controller = "Home" });
-            });
-        }
+            routes.MapRoute(
+                null,
+                "api/{controller}",
+                new { controller = "Home" });
+        });
     }
+}

--- a/src/BugTracker/Views/Home/Index.cshtml
+++ b/src/BugTracker/Views/Home/Index.cshtml
@@ -21,7 +21,7 @@
                 console.log('hub connection open');
             });
 
-            var bugsBaseAddress = encodeURIComponent('@Url.Content("~/api/bugs/")');
+            var bugsBaseAddress = encodeURI('@Url.Content("~/api/bugs/")');
             $.getJSON(bugsBaseAddress, function (data) {
                 var model = data;
 

--- a/src/BugTracker/project.json
+++ b/src/BugTracker/project.json
@@ -1,28 +1,25 @@
 ﻿{
-  "authors": [
-    "Microsoft"
-  ],
-  "description": "BugTracker application on K",
-  "version": "1.0.0-*",
-  "dependencies": {
+    "authors": [
+        "Microsoft"
+    ],
+    "description": "BugTracker application on K",
+    "version": "1.0.0-*",
+    "dependencies": {
+        "Kestrel": "1.0.0-*",
         "Microsoft.AspNet.Server.IIS": "1.0.0-*",
         "Microsoft.AspNet.Mvc": "6.0.0-*",
         "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
         "Microsoft.AspNet.Diagnostics": "1.0.0-*",
-        "Microsoft.AspNet.Security.Cookies": "1.0.0-*",
         "Microsoft.AspNet.StaticFiles": "1.0.0-*",
-        "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-*",
-        "Microsoft.Framework.OptionsModel": "1.0.0-*",
-	"Microsoft.AspNet.SignalR.Server": "3.0.0-*"
+        "Microsoft.AspNet.SignalR.Server": "3.0.0-*"
     },
     "commands": {
         "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5002",
+        "Kestrel": "Microsoft.AspNet.Hosting --server Kestrel --server.urls http://localhost:5004",
         "run": "run server.urls=http://localhost:5003"
     },
     "frameworks": {
-        "net451": {
-        },
-        "k10": {
-        }
+        "net451": { },
+        "k10": { }
     }
 }


### PR DESCRIPTION
Also fixed a URL issue. EncodeUriComponent renders the URI incorrect as it escapes / to %2F.
WebListener unescapes the / somehow making even an invalid URL to work. But Kestrel does not escape %2F resulting in 404.
Adding some instructions in readme as well.
