### PR TITLE
For issue 48: HostingServices does not contain a definition for GetDefau...

### DIFF
--- a/src/BugTracker/Program.cs
+++ b/src/BugTracker/Program.cs
@@ -27,9 +27,8 @@ namespace BugTracker
             config.AddCommandLine(args);
             
             var serviceCollection = new ServiceCollection();
-            serviceCollection.Add(HostingServices.GetDefaultServices(config));
-            serviceCollection.AddInstance<IHostingEnvironment>(new HostingEnvironment() { WebRoot = "wwwroot" });
-            var services = serviceCollection.BuildServiceProvider(_hostServiceProvider);
+            serviceCollection.Add(HostingServices.Create(_hostServiceProvider));
+            var services = serviceCollection.BuildServiceProvider();
 
             var context = new HostingContext()
             {


### PR DESCRIPTION
...ltService. To allow the BugTracker to work on mono (tested on Ubuntu 14.04)
